### PR TITLE
fix：修复使用同一对象，导致获取的对象的值与实际配置不一致问题

### DIFF
--- a/src/ZServer/Store/Configuration/SourceStore.cs
+++ b/src/ZServer/Store/Configuration/SourceStore.cs
@@ -53,7 +53,7 @@ namespace ZServer.Store.Configuration
         {
             if (Cache.TryGetValue(name, out var source))
             {
-                return await Task.FromResult(source);
+                return await Task.FromResult(source.Clone());
             }
 
             return null;


### PR DESCRIPTION
修复使用同一对象，导致获取的对象的值与实际配置不一致问题