### PR TITLE
feat: 图层级别增加 defaultFilter 支持

### DIFF
--- a/src/ZMap/FilterMerger.cs
+++ b/src/ZMap/FilterMerger.cs
@@ -1,0 +1,61 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ZMap;
+
+public static class FilterMerger
+{
+    public static string Merge(string defaultFilter, string requestFilter)
+    {
+        var hasDefault = !string.IsNullOrWhiteSpace(defaultFilter);
+        var hasRequest = !string.IsNullOrWhiteSpace(requestFilter);
+
+        if (!hasDefault && !hasRequest) return null;
+        if (!hasDefault) return requestFilter;
+        if (!hasRequest) return defaultFilter;
+
+        var defaultInfo = JObject.Parse(defaultFilter);
+        var defaultFilters = defaultInfo.Property("Filters")?.Value as JArray ?? new JArray();
+
+        var requestInfo = JObject.Parse(requestFilter);
+        var requestFilters = requestInfo.Property("Filters")?.Value as JArray ?? new JArray();
+
+        if (defaultFilters.Count == 0 && requestFilters.Count == 0)
+        {
+            return null;
+        }
+
+        var requestFields = new HashSet<string>();
+        foreach (var rf in requestFilters)
+        {
+            var field = rf["Field"]?.ToString();
+            if (field != null) requestFields.Add(field);
+        }
+
+        var merged = new JArray();
+        foreach (var df in defaultFilters)
+        {
+            var field = df["Field"]?.ToString();
+            if (field != null && requestFields.Contains(field)) continue;
+            merged.Add(df);
+        }
+
+        foreach (var rf in requestFilters)
+        {
+            merged.Add(rf);
+        }
+
+        if (merged.Count == 0)
+        {
+            return null;
+        }
+
+        var result = new JObject
+        {
+            ["Logic"] = "And",
+            ["Filters"] = merged
+        };
+
+        return result.ToString(Newtonsoft.Json.Formatting.None);
+    }
+}

--- a/src/ZMap/Layer.cs
+++ b/src/ZMap/Layer.cs
@@ -81,9 +81,15 @@ public partial class Layer : IVisibleLimit
     public HashSet<ServiceType> Services { get; set; }
 
     /// <summary>
-    /// 过滤条件
+    /// 前端传入的过滤条件（运行时赋值）
     /// </summary>
     public string Filter { get; set; }
+
+    /// <summary>
+    /// 默认过滤条件（配置级别），DynamicFilterInfo JSON 格式。
+    /// 前端未传入 filter 时追加；前端传入同名 Field 时以前端为准。
+    /// </summary>
+    public string DefaultFilter { get; set; }
 
     /// <summary>
     /// HttpClient 工厂
@@ -216,7 +222,8 @@ public partial class Layer : IVisibleLimit
             MaxZoom = MaxZoom,
             ZoomUnit = ZoomUnit,
             Enabled = Enabled,
-            Buffers = Buffers
+            Buffers = Buffers,
+            DefaultFilter = DefaultFilter
         };
     }
 

--- a/src/ZMap/Ogc/Wms/WmsService.cs
+++ b/src/ZMap/Ogc/Wms/WmsService.cs
@@ -56,7 +56,8 @@ public class WmsService(
             {
                 var layer = layerList[i];
                 layer.HttpClientFactory = httpClientFactory;
-                layer.Filter = requestParameters.Filters.ElementAtOrDefault(i);
+                layer.Filter = FilterMerger.Merge(layer.DefaultFilter,
+                    requestParameters.Filters.ElementAtOrDefault(i));
 
                 var permission =
                     await permissionService.EnforceAsync("read", layer.ResourceId, PolicyEffect.Allow);
@@ -129,6 +130,12 @@ public class WmsService(
 
             var tuple = await layerQueryService.GetLayersAsync(layerQueries, traceIdentifier);
             var layerList = tuple.Layers;
+
+            foreach (var layer in layerList)
+            {
+                layer.Filter = FilterMerger.Merge(layer.DefaultFilter, null);
+            }
+
             var featureCollection = await GetFeatureInfoAsync(layerList, featureCount, srs,
                 validateResult.Parameters.Envelope,
                 width, height, x, y);
@@ -198,7 +205,7 @@ public class WmsService(
             var envelope = new Envelope(minX, maxX, minY, maxY);
             var targetEnvelope = envelope.Transform(srid, spatialDatabaseSource.Srid);
             var features = await spatialDatabaseSource
-                .GetFeaturesAsync(targetEnvelope, null);
+                .GetFeaturesAsync(targetEnvelope, layer.Filter);
 
             foreach (var feature in features)
             {

--- a/src/ZMap/Ogc/Wmts/WmtsService.cs
+++ b/src/ZMap/Ogc/Wmts/WmtsService.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http;
+using System.Net.Http;
 
 namespace ZMap.Ogc.Wmts;
 
@@ -48,72 +48,20 @@ public class WmtsService(
                     $"Could not find tile matrix set {tileMatrixSet}");
             }
 
-            var tuple = Utility.GetWmtsPath(layers, zFilter, format, tileMatrixSet, tileMatrix, tileRow, tileCol);
-            if (string.IsNullOrEmpty(tuple.FullPath))
-            {
-                displayUrl = GetTileDisplayUrl(traceIdentifier, layers, styles, format, tileMatrixSet, tileMatrix,
-                    tileRow, tileCol, zFilter);
-                Logger.Value.LogError("{Url}, wmts key is empty", displayUrl);
-                return new MapResult(Stream.Null, "WMTSKeyIsEmpty",
-                    "wmts key is empty");
-            }
-
-#if !DEBUG
-            if (File.Exists(tuple.FullPath))
-            {
-                if (EnvironmentVariables.EnableSensitiveDataLogging)
-                {
-                    displayUrl = GetTileDisplayUrl(traceIdentifier, layers, styles, format, tileMatrixSet, tileMatrix,
-                        tileRow, tileCol, zFilter);
-                    Logger.Value.LogInformation("[{TraceIdentifier}] {Url}, CACHED", traceIdentifier, displayUrl);
-                }
-
-                return new MapResult(File.OpenRead(tuple.FullPath), null, null);
-            }
-#endif
-
-            var folder = Path.GetDirectoryName(tuple.FullPath);
-            // TODO: 优化减小磁盘 IO
-            if (folder != null && !Directory.Exists(folder))
-            {
-                Directory.CreateDirectory(folder);
-            }
-
-            var gridSetEnvelope = gridSet.GetEnvelope(tileMatrix, tileCol, tileRow);
-            if (gridSetEnvelope == null)
-            {
-                displayUrl = GetTileDisplayUrl(traceIdentifier, layers, styles, format, tileMatrixSet, tileMatrix,
-                    tileRow, tileCol, zFilter);
-                Logger.Value.LogError("{Url}, could not get envelope from grid set", displayUrl);
-                return new MapResult(Stream.Null, null, null);
-            }
-
-            var layerQueries =
-                new List<LayerQuery>();
-
             var layerNames = layers.Split(',', StringSplitOptions.RemoveEmptyEntries);
-            // 如果有多个图层过滤条件
             var filterList = string.IsNullOrEmpty(zFilter)
                 ? []
                 : zFilter.Split(';', StringSplitOptions.RemoveEmptyEntries);
-            if (filterList.Length > 0 && filterList.Length != layerNames.Length)
-            {
-                return new MapResult(Stream.Null, "FilterDefinedError", "filter count not match layer count");
-            }
-
             var styleList = string.IsNullOrEmpty(styles)
                 ? []
                 : styles.Split(';', StringSplitOptions.RemoveEmptyEntries);
-            if (styleList.Length > 0 && styleList.Length != layerNames.Length)
-            {
-                return new MapResult(Stream.Null, "StyleDefinedError", "style count not match layer count");
-            }
+
+            var layerQueries = new List<LayerQuery>();
 
             for (var i = 0; i < layerNames.Length; i++)
             {
                 var layerName = layerNames[i];
                 var layerQuery = layerName.Split(':', StringSplitOptions.RemoveEmptyEntries);
-                // var filter = filterList.ElementAtOrDefault(i);
                 switch (layerQuery.Length)
                 {
                     case 2:
@@ -142,11 +90,24 @@ public class WmtsService(
                 return new MapResult(Stream.Null, "QueryLayerError", null);
             }
 
+            if (filterList.Length > 0 && filterList.Length != layerList.Count)
+            {
+                return new MapResult(Stream.Null, "FilterDefinedError", "filter count not match layer count");
+            }
+
+            if (styleList.Length > 0 && styleList.Length != layerList.Count)
+            {
+                return new MapResult(Stream.Null, "StyleDefinedError", "style count not match layer count");
+            }
+
+            var mergedFilters = new string[layerList.Count];
             for (var i = 0; i < layerList.Count; ++i)
             {
                 var layer = layerList[i];
                 layer.HttpClientFactory = httpClientFactory;
-                layer.Filter = filterList.ElementAtOrDefault(i);
+                mergedFilters[i] = FilterMerger.Merge(layer.DefaultFilter,
+                    filterList.ElementAtOrDefault(i));
+                layer.Filter = mergedFilters[i];
 
                 var permission =
                     await permissionService.EnforceAsync("read", layer.ResourceId, PolicyEffect.Allow);
@@ -156,6 +117,48 @@ public class WmtsService(
                 }
 
                 return new MapResult(Stream.Null, "403", "Forbidden");
+            }
+
+            var mergedFilterStr = string.Join(";", mergedFilters.Where(f => f != null));
+            var tuple = Utility.GetWmtsPath(layers, mergedFilterStr, format, tileMatrixSet, tileMatrix, tileRow,
+                tileCol);
+            if (string.IsNullOrEmpty(tuple.FullPath))
+            {
+                displayUrl = GetTileDisplayUrl(traceIdentifier, layers, styles, format, tileMatrixSet, tileMatrix,
+                    tileRow, tileCol, mergedFilterStr);
+                Logger.Value.LogError("{Url}, wmts key is empty", displayUrl);
+                return new MapResult(Stream.Null, "WMTSKeyIsEmpty",
+                    "wmts key is empty");
+            }
+
+#if !DEBUG
+            if (File.Exists(tuple.FullPath))
+            {
+                if (EnvironmentVariables.EnableSensitiveDataLogging)
+                {
+                    displayUrl = GetTileDisplayUrl(traceIdentifier, layers, styles, format, tileMatrixSet, tileMatrix,
+                        tileRow, tileCol, mergedFilterStr);
+                    Logger.Value.LogInformation("[{TraceIdentifier}] {Url}, CACHED", traceIdentifier, displayUrl);
+                }
+
+                return new MapResult(File.OpenRead(tuple.FullPath), null, null);
+            }
+#endif
+
+            var folder = Path.GetDirectoryName(tuple.FullPath);
+            // TODO: 优化减小磁盘 IO
+            if (folder != null && !Directory.Exists(folder))
+            {
+                Directory.CreateDirectory(folder);
+            }
+
+            var gridSetEnvelope = gridSet.GetEnvelope(tileMatrix, tileCol, tileRow);
+            if (gridSetEnvelope == null)
+            {
+                displayUrl = GetTileDisplayUrl(traceIdentifier, layers, styles, format, tileMatrixSet, tileMatrix,
+                    tileRow, tileCol, mergedFilterStr);
+                Logger.Value.LogError("{Url}, could not get envelope from grid set", displayUrl);
+                return new MapResult(Stream.Null, null, null);
             }
 
             var scale = gridSetEnvelope.ScaleDenominator;

--- a/src/ZServer.Tests/DefaultFilterTests.cs
+++ b/src/ZServer.Tests/DefaultFilterTests.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using ZMap.Source.Postgre;
+using ZServer.Store;
+
+namespace ZServer.Tests;
+
+public class DefaultFilterTests
+{
+    [Fact]
+    public async Task LayerStore_Reads_DefaultFilter()
+    {
+        var json = JsonConvert.DeserializeObject(await File.ReadAllTextAsync("layers.json")) as JObject;
+        var styleGroupStore = new StyleGroupStore();
+        await styleGroupStore.RefreshAsync(new List<JObject> { json });
+        var resourceGroupStore = new ResourceGroupStore();
+        await resourceGroupStore.RefreshAsync(new List<JObject> { json });
+        var sourceStore = new SourceStore();
+        await sourceStore.RefreshAsync(new List<JObject> { json });
+        var sldStore = new SldStore();
+        await sldStore.RefreshAsync(new List<JObject> { json });
+
+        var store = new LayerStore(styleGroupStore, resourceGroupStore, sourceStore, sldStore);
+        await store.RefreshAsync(new List<JObject> { json });
+
+        var layer = await store.FindAsync("resourceGroup1", "berlin_db_filtered");
+        Assert.NotNull(layer);
+        Assert.Equal("berlin_db_filtered", layer.Name);
+        Assert.False(string.IsNullOrEmpty(layer.DefaultFilter));
+        Assert.Contains("status", layer.DefaultFilter);
+        Assert.Contains("Equal", layer.DefaultFilter);
+    }
+
+    [Fact]
+    public async Task LayerStore_DefaultFilter_Null_When_Not_Configured()
+    {
+        var json = JsonConvert.DeserializeObject(await File.ReadAllTextAsync("layers.json")) as JObject;
+        var styleGroupStore = new StyleGroupStore();
+        await styleGroupStore.RefreshAsync(new List<JObject> { json });
+        var resourceGroupStore = new ResourceGroupStore();
+        await resourceGroupStore.RefreshAsync(new List<JObject> { json });
+        var sourceStore = new SourceStore();
+        await sourceStore.RefreshAsync(new List<JObject> { json });
+        var sldStore = new SldStore();
+        await sldStore.RefreshAsync(new List<JObject> { json });
+
+        var store = new LayerStore(styleGroupStore, resourceGroupStore, sourceStore, sldStore);
+        await store.RefreshAsync(new List<JObject> { json });
+
+        var layer = await store.FindAsync("resourceGroup1", "berlin_db");
+        Assert.NotNull(layer);
+        Assert.Null(layer.DefaultFilter);
+    }
+
+    [Fact]
+    public async Task Layer_Clone_Copies_DefaultFilter()
+    {
+        var json = JsonConvert.DeserializeObject(await File.ReadAllTextAsync("layers.json")) as JObject;
+        var styleGroupStore = new StyleGroupStore();
+        await styleGroupStore.RefreshAsync(new List<JObject> { json });
+        var resourceGroupStore = new ResourceGroupStore();
+        await resourceGroupStore.RefreshAsync(new List<JObject> { json });
+        var sourceStore = new SourceStore();
+        await sourceStore.RefreshAsync(new List<JObject> { json });
+        var sldStore = new SldStore();
+        await sldStore.RefreshAsync(new List<JObject> { json });
+
+        var store = new LayerStore(styleGroupStore, resourceGroupStore, sourceStore, sldStore);
+        await store.RefreshAsync(new List<JObject> { json });
+
+        var layer = await store.FindAsync("resourceGroup1", "berlin_db_filtered");
+        Assert.NotNull(layer);
+
+        var cloned = layer.Clone();
+        Assert.Equal(layer.DefaultFilter, cloned.DefaultFilter);
+        Assert.Equal(layer.Name, cloned.Name);
+    }
+
+    [Fact]
+    public async Task FilterMerger_Integration_With_DefaultFilter()
+    {
+        var json = JsonConvert.DeserializeObject(await File.ReadAllTextAsync("layers.json")) as JObject;
+        var styleGroupStore = new StyleGroupStore();
+        await styleGroupStore.RefreshAsync(new List<JObject> { json });
+        var resourceGroupStore = new ResourceGroupStore();
+        await resourceGroupStore.RefreshAsync(new List<JObject> { json });
+        var sourceStore = new SourceStore();
+        await sourceStore.RefreshAsync(new List<JObject> { json });
+        var sldStore = new SldStore();
+        await sldStore.RefreshAsync(new List<JObject> { json });
+
+        var store = new LayerStore(styleGroupStore, resourceGroupStore, sourceStore, sldStore);
+        await store.RefreshAsync(new List<JObject> { json });
+
+        var layer = await store.FindAsync("resourceGroup1", "berlin_db_filtered");
+        Assert.NotNull(layer);
+
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "type",
+                  "Operator": "Equal",
+                  "Value": "building"
+                }
+              ]
+            }
+            """;
+
+        var merged = ZMap.FilterMerger.Merge(layer.DefaultFilter, requestFilter);
+        Assert.Contains("status", merged);
+        Assert.Contains("type", merged);
+        Assert.Contains("building", merged);
+    }
+}

--- a/src/ZServer.Tests/FilterMergerTests.cs
+++ b/src/ZServer.Tests/FilterMergerTests.cs
@@ -1,0 +1,383 @@
+using ZMap;
+using Xunit;
+
+namespace ZServer.Tests;
+
+public class FilterMergerTests
+{
+    private const string DefaultFilterJson = """
+        {
+          "Logic": "And",
+          "Filters": [
+            {
+              "Field": "status",
+              "Operator": "Equal",
+              "Value": 1
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void Both_null_returns_null()
+    {
+        var result = FilterMerger.Merge(null, null);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Empty_strings_returns_null()
+    {
+        var result = FilterMerger.Merge("", "  ");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Only_default_filter()
+    {
+        var result = FilterMerger.Merge(DefaultFilterJson, null);
+        Assert.Contains("\"status\"", result);
+        Assert.Contains("\"Equal\"", result);
+    }
+
+    [Fact]
+    public void Only_request_filter()
+    {
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "type",
+                  "Operator": "Equal",
+                  "Value": "building"
+                }
+              ]
+            }
+            """;
+
+        var result = FilterMerger.Merge(null, requestFilter);
+        Assert.Contains("\"type\"", result);
+        Assert.Contains("\"building\"", result);
+    }
+
+    [Fact]
+    public void Merge_different_fields_keeps_both()
+    {
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "type",
+                  "Operator": "Equal",
+                  "Value": "building"
+                }
+              ]
+            }
+            """;
+
+        var result = FilterMerger.Merge(DefaultFilterJson, requestFilter);
+
+        Assert.Contains("\"status\"", result);
+        Assert.Contains("\"type\"", result);
+    }
+
+    [Fact]
+    public void Merge_same_field_request_wins()
+    {
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "status",
+                  "Operator": "Equal",
+                  "Value": 2
+                }
+              ]
+            }
+            """;
+
+        var result = FilterMerger.Merge(DefaultFilterJson, requestFilter);
+
+        Assert.Contains("\"status\"", result);
+        Assert.Contains("2", result);
+        Assert.DoesNotContain("\"Value\":1", result);
+    }
+
+    [Fact]
+    public void Merge_default_has_two_fields_request_overrides_one()
+    {
+        var defaultFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "status",
+                  "Operator": "Equal",
+                  "Value": 1
+                },
+                {
+                  "Field": "category",
+                  "Operator": "Equal",
+                  "Value": "A"
+                }
+              ]
+            }
+            """;
+
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "status",
+                  "Operator": "GreaterThan",
+                  "Value": 5
+                }
+              ]
+            }
+            """;
+
+        var result = FilterMerger.Merge(defaultFilter, requestFilter);
+
+        Assert.Contains("\"category\"", result);
+        Assert.Contains("\"A\"", result);
+        Assert.Contains("\"status\"", result);
+        Assert.Contains("5", result);
+    }
+
+    [Fact]
+    public void Merge_result_logic_is_always_and()
+    {
+        var requestFilter = """
+            {
+              "Logic": "Or",
+              "Filters": [
+                {
+                  "Field": "type",
+                  "Operator": "Equal",
+                  "Value": "road"
+                }
+              ]
+            }
+            """;
+
+        var result = FilterMerger.Merge(DefaultFilterJson, requestFilter);
+
+        Assert.Contains("\"Logic\":\"And\"", result);
+    }
+
+    [Fact]
+    public void Merge_with_empty_default()
+    {
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "type",
+                  "Operator": "Equal",
+                  "Value": "building"
+                }
+              ]
+            }
+            """;
+
+        var result = FilterMerger.Merge("", requestFilter);
+        Assert.Contains("\"type\"", result);
+    }
+
+    [Fact]
+    public void Merge_with_empty_request()
+    {
+        var result = FilterMerger.Merge(DefaultFilterJson, "");
+        Assert.Contains("\"status\"", result);
+    }
+
+    [Fact]
+    public void Merge_multiple_fields_all_overridden()
+    {
+        var defaultFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "status",
+                  "Operator": "Equal",
+                  "Value": 1
+                },
+                {
+                  "Field": "category",
+                  "Operator": "Equal",
+                  "Value": "A"
+                }
+              ]
+            }
+            """;
+
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "status",
+                  "Operator": "Equal",
+                  "Value": 99
+                },
+                {
+                  "Field": "category",
+                  "Operator": "Equal",
+                  "Value": "Z"
+                }
+              ]
+            }
+            """;
+
+        var result = FilterMerger.Merge(defaultFilter, requestFilter);
+
+        Assert.Contains("\"status\"", result);
+        Assert.Contains("99", result);
+        Assert.Contains("\"category\"", result);
+        Assert.Contains("\"Z\"", result);
+        Assert.DoesNotContain("\"Value\":1", result);
+        Assert.DoesNotContain("\"A\"", result);
+    }
+
+    // === 新增边界条件测试 ===
+
+    [Fact]
+    public void Both_filters_with_empty_arrays_returns_null()
+    {
+        var defaultFilter = """{"Logic":"And","Filters":[]}""";
+        var requestFilter = """{"Logic":"And","Filters":[]}""";
+
+        var result = FilterMerger.Merge(defaultFilter, requestFilter);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Default_filter_with_empty_array_and_valid_request()
+    {
+        var defaultFilter = """{"Logic":"And","Filters":[]}""";
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "type",
+                  "Operator": "Equal",
+                  "Value": "building"
+                }
+              ]
+            }
+            """;
+
+        var result = FilterMerger.Merge(defaultFilter, requestFilter);
+        Assert.Contains("\"type\"", result);
+    }
+
+    [Fact]
+    public void Valid_default_and_request_with_empty_array()
+    {
+        var requestFilter = """{"Logic":"And","Filters":[]}""";
+
+        var result = FilterMerger.Merge(DefaultFilterJson, requestFilter);
+        Assert.Contains("\"status\"", result);
+    }
+
+    [Fact]
+    public void Invalid_default_filter_json_throws()
+    {
+        var invalidDefault = "not valid json {{{";
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "type",
+                  "Operator": "Equal",
+                  "Value": "building"
+                }
+              ]
+            }
+            """;
+
+        Assert.ThrowsAny<Newtonsoft.Json.JsonException>(() =>
+            FilterMerger.Merge(invalidDefault, requestFilter));
+    }
+
+    [Fact]
+    public void Invalid_request_filter_json_throws()
+    {
+        var invalidRequest = "broken json <<<";
+        Assert.ThrowsAny<Newtonsoft.Json.JsonException>(() =>
+            FilterMerger.Merge(DefaultFilterJson, invalidRequest));
+    }
+
+    [Fact]
+    public void Both_invalid_json_throws()
+    {
+        Assert.ThrowsAny<Newtonsoft.Json.JsonException>(() =>
+            FilterMerger.Merge("bad{", "also bad}"));
+    }
+
+    [Fact]
+    public void Filter_without_Filters_property_treated_as_empty()
+    {
+        var defaultFilter = """{"Logic":"And"}""";
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "type",
+                  "Operator": "Equal",
+                  "Value": "road"
+                }
+              ]
+            }
+            """;
+
+        var result = FilterMerger.Merge(defaultFilter, requestFilter);
+        Assert.Contains("\"type\"", result);
+    }
+
+    [Fact]
+    public void Filter_item_without_field_is_preserved()
+    {
+        // 没有 Field 的 filter 条件（如嵌套子条件）不应被去重逻辑干扰
+        var defaultFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Logic": "Or",
+                  "Filters": [
+                    {"Field": "a", "Operator": "Equal", "Value": 1},
+                    {"Field": "b", "Operator": "Equal", "Value": 2}
+                  ]
+                }
+              ]
+            }
+            """;
+        var requestFilter = """
+            {
+              "Logic": "And",
+              "Filters": [
+                {
+                  "Field": "c",
+                  "Operator": "Equal",
+                  "Value": 3
+                }
+              ]
+            }
+            """;
+
+        var result = FilterMerger.Merge(defaultFilter, requestFilter);
+        Assert.Contains("\"a\"", result);
+        Assert.Contains("\"b\"", result);
+        Assert.Contains("\"c\"", result);
+    }
+}

--- a/src/ZServer.Tests/LayerStoreTests.cs
+++ b/src/ZServer.Tests/LayerStoreTests.cs
@@ -42,6 +42,27 @@ public class LayerStoreTests : BaseTests
         await Test1(store);
         await Test2(store);
         await Test3(store);
+        await TestDefaultFilter(store);
+    }
+
+    [Fact]
+    public async Task LoadDefaultFilter()
+    {
+        var store = GetScopedService<ILayerStore>();
+        await TestDefaultFilter(store);
+    }
+
+    private async Task TestDefaultFilter(ILayerStore store)
+    {
+        var layer = await store.FindAsync("resourceGroup1", "berlin_db_filtered");
+        Assert.NotNull(layer);
+        Assert.Equal("berlin_db_filtered", layer.Name);
+        Assert.False(string.IsNullOrEmpty(layer.DefaultFilter));
+        Assert.Contains("status", layer.DefaultFilter);
+        Assert.Contains("Equal", layer.DefaultFilter);
+
+        var cloned = layer.Clone();
+        Assert.Equal(layer.DefaultFilter, cloned.DefaultFilter);
     }
 
     [Fact]
@@ -196,10 +217,14 @@ public class LayerStoreTests : BaseTests
     {
         var layers = await store.GetAllAsync();
         Assert.NotNull(layers);
-        Assert.Equal(2, layers.Count);
+        Assert.Equal(3, layers.Count);
 
         var pgLayer = layers.First(x => x.Name == "berlin_db");
         var shpLayer = layers.First(x => x.Name == "berlin_shp");
+        var filteredLayer = layers.First(x => x.Name == "berlin_db_filtered");
+        Assert.NotNull(filteredLayer);
+        Assert.False(string.IsNullOrEmpty(filteredLayer.DefaultFilter));
+        Assert.Contains("status", filteredLayer.DefaultFilter);
         Assert.Equal("berlin_db", pgLayer.Name);
         Assert.Equal("berlin_shp", shpLayer.Name);
 

--- a/src/ZServer.Tests/layers.json
+++ b/src/ZServer.Tests/layers.json
@@ -186,6 +186,18 @@
       "styleGroups": [
         "style1"
       ]
+    },
+    "berlin_db_filtered": {
+      "resourceGroup": "resourceGroup1",
+      "services": [],
+      "source": "berlin_db",
+      "sourceTable": "osmbuildings",
+      "sourceGeometry": "geom",
+      "sourceSRID": 4326,
+      "defaultFilter": "{\"Logic\":\"And\",\"Filters\":[{\"Field\":\"status\",\"Operator\":\"Equal\",\"Value\":1}]}",
+      "styleGroups": [
+        "style1"
+      ]
     }
   },
   "gridSets": {

--- a/src/ZServer/Store/LayerStore.cs
+++ b/src/ZServer/Store/LayerStore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -32,6 +33,7 @@ public class LayerStore(
     {
         var existKeys = Cache.Keys.ToList();
         var keys = new List<string>();
+        var changedLayerKeys = new List<string>();
 
         foreach (var configuration in configurations)
         {
@@ -50,6 +52,14 @@ public class LayerStore(
                     ? null
                     : await resourceGroupStore.FindAsync(resourceGroupName);
 
+                var newDefaultFilter = section.Value["defaultFilter"]?.ToObject<string>();
+
+                if (Cache.TryGetValue(name, out var oldLayer)
+                    && oldLayer.DefaultFilter != newDefaultFilter)
+                {
+                    changedLayerKeys.Add(name);
+                }
+
                 var layer = await BindLayerAsync(name, section.Value as JObject, resourceGroup);
                 if (layer == null)
                 {
@@ -65,6 +75,34 @@ public class LayerStore(
         foreach (var removedKey in removedKeys)
         {
             Cache.TryRemove(removedKey, out _);
+        }
+
+        ClearWmtsCache(changedLayerKeys);
+    }
+
+    private static void ClearWmtsCache(List<string> layerKeys)
+    {
+        if (layerKeys.Count == 0) return;
+
+        var cacheRoot = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "cache", "wmts");
+        if (!Directory.Exists(cacheRoot)) return;
+
+        foreach (var layerKey in layerKeys)
+        {
+            // layerKey 可能是 "resourceGroup:layer" 或 "layer"，缓存路径用 ':'→'_' 替换
+            var dirName = layerKey.Replace(':', '_');
+            var layerDir = Path.Combine(cacheRoot, dirName);
+            if (!Directory.Exists(layerDir)) continue;
+
+            try
+            {
+                Directory.Delete(layerDir, true);
+                Logger.Value.LogInformation("已清除图层 {Layer} 的 WMTS 缓存: {Path}", layerKey, layerDir);
+            }
+            catch (Exception ex)
+            {
+                Logger.Value.LogError(ex, "清除图层 {Layer} 的 WMTS 缓存失败: {Path}", layerKey, layerDir);
+            }
         }
     }
 
@@ -204,7 +242,8 @@ public class LayerStore(
         var layer = new Layer(resourceGroup, services, name, source, styleGroups, envelope)
         {
             Buffers = section["buffers"]?.ToObject<List<GridBuffer>>() ?? new List<GridBuffer>(),
-            Enabled = section["enabled"]?.ToObject<bool>() ?? true
+            Enabled = section["enabled"]?.ToObject<bool>() ?? true,
+            DefaultFilter = section["defaultFilter"]?.ToObject<string>()
         };
         return layer;
     }


### PR DESCRIPTION
- Layer 新增 DefaultFilter 属性，配置级别 DynamicFilterInfo JSON 格式
- LayerStore 读取 defaultFilter 配置并在刷新时检测变化，变化时清除 WMTS 缓存
- FilterMerger 按 Field 级别合并 defaultFilter 与前端 Z_FILTER，前端同名字段优先
- WmsService.GetMapAsync / GetFeatureInfoAsync 均应用 FilterMerger 合并逻辑
- WmtsService 重构流程：先合并 filter 再计算缓存路径，日志输出合并后的 filter
- WmtsService filterList/styleList 长度校验移到图层查询之后
- 新增 FilterMergerTests (15 个) 和 DefaultFilterTests (4 个) 覆盖边界条件